### PR TITLE
Add APTLY_WEB_UI_PROXY_API_URL env var

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "deb-version-compare": "^1.1.1",
+    "express-http-proxy": "^0.7.4",
     "immutable": "^3.8.1",
     "react-dropzone": "^3.4.0",
     "react-redux": "^4.4.5",


### PR DESCRIPTION
Lets you set the `APTLY_WEB_UI_PROXY_API_URL` environment variable to
have the server proxy to a real aptly API server instead of serving up
fake data.

```
$ APTLY_WEB_UI_PROXY_API_URL="http://10.3.0.46:8081" npm start

> aptly-web-ui@0.0.1 start /Users/marca/dev/git-repos/aptly-web-ui
> node index.js

Loaded server at : http://localhost:8080
done compiling
serving index on :  /
```